### PR TITLE
Set max consecutive futile launches

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Suppress interactive browser on Windows which launched on each worker previously (@psychelzh).
 * Migrate to the new host/daemon nomenclature in `mirai` 0.9.1 (#96).
 * Suppress `status()` retries (@shikokuchuo, #100).
+* Implement `launch_max` to error out if workers repeatedly launch without completing any tasks (#101, @shikokuchuo, @multimeric).
 
 # crew 0.4.0
 

--- a/R/crew_controller_local.R
+++ b/R/crew_controller_local.R
@@ -33,7 +33,8 @@ crew_controller_local <- function(
   reset_globals = TRUE,
   reset_packages = FALSE,
   reset_options = FALSE,
-  garbage_collection = FALSE
+  garbage_collection = FALSE,
+  launch_max = 5L
 ) {
   client <- crew_client(
     name = name,
@@ -57,7 +58,8 @@ crew_controller_local <- function(
     reset_globals = reset_globals,
     reset_packages = reset_packages,
     reset_options = reset_options,
-    garbage_collection = garbage_collection
+    garbage_collection = garbage_collection,
+    launch_max = launch_max
   )
   controller <- crew_controller(client = client, launcher = launcher)
   controller$validate()

--- a/R/crew_launcher.R
+++ b/R/crew_launcher.R
@@ -491,7 +491,7 @@ crew_class_launcher <- R6::R6Class(
       futile <- self$workers$futile[index]
       futile <- if_any(complete > history, 0L, futile + 1L)
       crew_assert(
-        futile < self$launch_max,
+        futile <= self$launch_max,
         message = paste(
           "{crew} worker",
           index,

--- a/R/crew_launcher_local.R
+++ b/R/crew_launcher_local.R
@@ -27,7 +27,8 @@ crew_launcher_local <- function(
   reset_globals = TRUE,
   reset_packages = FALSE,
   reset_options = FALSE,
-  garbage_collection = FALSE
+  garbage_collection = FALSE,
+  launch_max = 5L
 ) {
   name <- as.character(name %|||% crew_random_name())
   launcher <- crew_class_launcher_local$new(
@@ -42,7 +43,8 @@ crew_launcher_local <- function(
     reset_globals = reset_globals,
     reset_packages = reset_packages,
     reset_options = reset_options,
-    garbage_collection = garbage_collection
+    garbage_collection = garbage_collection,
+    launch_max = launch_max
   )
   launcher$validate()
   launcher

--- a/man/crew_class_launcher.Rd
+++ b/man/crew_class_launcher.Rd
@@ -85,6 +85,8 @@ Other class:
 
 \item{\code{garbage_collection}}{See \code{\link[=crew_launcher]{crew_launcher()}}.}
 
+\item{\code{launch_max}}{See \code{\link[=crew_launcher]{crew_launcher()}}.}
+
 \item{\code{until}}{Numeric of length 1, time point when throttled unlocks.}
 }
 \if{html}{\out{</div>}}
@@ -129,7 +131,8 @@ Launcher constructor.
   reset_globals = NULL,
   reset_packages = NULL,
   reset_options = NULL,
-  garbage_collection = NULL
+  garbage_collection = NULL,
+  launch_max = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -159,6 +162,8 @@ Launcher constructor.
 \item{\code{reset_options}}{See \code{\link[=crew_launcher]{crew_launcher()}}.}
 
 \item{\code{garbage_collection}}{See \code{\link[=crew_launcher]{crew_launcher()}}.}
+
+\item{\code{launch_max}}{See \code{\link[=crew_launcher]{crew_launcher()}}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/crew_controller_local.Rd
+++ b/man/crew_controller_local.Rd
@@ -22,7 +22,8 @@ crew_controller_local(
   reset_globals = TRUE,
   reset_packages = FALSE,
   reset_options = FALSE,
-  garbage_collection = FALSE
+  garbage_collection = FALSE,
+  launch_max = 5L
 )
 }
 \arguments{
@@ -122,6 +123,16 @@ because packages sometimes rely on options they set at loading time.}
 
 \item{garbage_collection}{\code{TRUE} to run garbage collection between
 tasks, \code{FALSE} to skip.}
+
+\item{launch_max}{Positive integer of length 1, maximum allowed
+consecutive launch attempts which do not complete any tasks.
+Enforced on a worker-by-worker basis.
+The futile launch count resets to back 0
+for each worker that completes a task.
+It is recommended to set \code{launch_max} above 0
+because sometimes workers are unproductive under perfectly ordinary
+circumstances. But \code{launch_max} should still be small enough
+to detect errors in the underlying platform.}
 }
 \description{
 Create an \code{R6} object to submit tasks and

--- a/man/crew_launcher.Rd
+++ b/man/crew_launcher.Rd
@@ -16,7 +16,8 @@ crew_launcher(
   reset_globals = TRUE,
   reset_packages = FALSE,
   reset_options = FALSE,
-  garbage_collection = FALSE
+  garbage_collection = FALSE,
+  launch_max = 5L
 )
 }
 \arguments{
@@ -73,6 +74,16 @@ because packages sometimes rely on options they set at loading time.}
 
 \item{garbage_collection}{\code{TRUE} to run garbage collection between
 tasks, \code{FALSE} to skip.}
+
+\item{launch_max}{Positive integer of length 1, maximum allowed
+consecutive launch attempts which do not complete any tasks.
+Enforced on a worker-by-worker basis.
+The futile launch count resets to back 0
+for each worker that completes a task.
+It is recommended to set \code{launch_max} above 0
+because sometimes workers are unproductive under perfectly ordinary
+circumstances. But \code{launch_max} should still be small enough
+to detect errors in the underlying platform.}
 }
 \description{
 This function is useful for inheriting argument documentation

--- a/man/crew_launcher_local.Rd
+++ b/man/crew_launcher_local.Rd
@@ -16,7 +16,8 @@ crew_launcher_local(
   reset_globals = TRUE,
   reset_packages = FALSE,
   reset_options = FALSE,
-  garbage_collection = FALSE
+  garbage_collection = FALSE,
+  launch_max = 5L
 )
 }
 \arguments{
@@ -73,6 +74,16 @@ because packages sometimes rely on options they set at loading time.}
 
 \item{garbage_collection}{\code{TRUE} to run garbage collection between
 tasks, \code{FALSE} to skip.}
+
+\item{launch_max}{Positive integer of length 1, maximum allowed
+consecutive launch attempts which do not complete any tasks.
+Enforced on a worker-by-worker basis.
+The futile launch count resets to back 0
+for each worker that completes a task.
+It is recommended to set \code{launch_max} above 0
+because sometimes workers are unproductive under perfectly ordinary
+circumstances. But \code{launch_max} should still be small enough
+to detect errors in the underlying platform.}
 }
 \description{
 Create an \code{R6} object to launch and maintain

--- a/tests/interactive/test-launch_max.R
+++ b/tests/interactive/test-launch_max.R
@@ -1,0 +1,38 @@
+# Run manually and watch htop.
+# Pause between launches to allow workers to idle out.
+library(crew)
+library(testthat)
+x <- crew_controller_local(
+  workers = 1L,
+  seconds_idle = 1e-9,
+  launch_max = 3L
+)
+x$start()
+expect_equal(x$launcher$workers$futile, 0L)
+x$launch(n = 1L)
+# Pause until worker idles out.
+expect_equal(x$launcher$workers$futile, 1L)
+x$launch(n = 1L)
+# Pause until worker idles out.
+expect_equal(x$launcher$workers$futile, 2L)
+x$launcher$seconds_idle <- Inf
+x$push(TRUE)
+x$wait()
+expect_equal(x$launcher$workers$futile, 3L)
+x$launcher$terminate(1L)
+# Pause until worker exits.
+x$launcher$seconds_idle <- 1e-9
+x$launch(n = 1L)
+# Pause until worker exits.
+expect_equal(x$launcher$workers$futile, 0L)
+x$launch(n = 1L)
+# Pause until worker exits.
+expect_equal(x$launcher$workers$futile, 1L)
+x$launch(n = 1L)
+# Pause until worker exits.
+expect_equal(x$launcher$workers$futile, 2L)
+x$launch(n = 1L)
+# Pause until worker exits.
+expect_equal(x$launcher$workers$futile, 3L)
+expect_error(x$launch(n = 1L), class = "crew_error")
+x$terminate()

--- a/tests/launchers/test-launcher-system2.R
+++ b/tests/launchers/test-launcher-system2.R
@@ -33,7 +33,8 @@ crew_controller_system2 <- function(
   reset_globals = TRUE,
   reset_packages = FALSE,
   reset_options = FALSE,
-  garbage_collection = FALSE
+  garbage_collection = FALSE,
+  launch_max = 5L
 ) {
   client <- crew::crew_client(
     name = name,
@@ -57,7 +58,8 @@ crew_controller_system2 <- function(
     reset_globals = reset_globals,
     reset_packages = reset_packages,
     reset_options = reset_options,
-    garbage_collection = garbage_collection
+    garbage_collection = garbage_collection,
+    launch_max = launch_max
   )
   controller <- crew::crew_controller(client = client, launcher = launcher)
   controller$validate()

--- a/tests/testthat/test-crew_controller_local.R
+++ b/tests/testthat/test-crew_controller_local.R
@@ -536,28 +536,3 @@ crew_test("map() does not need an empty controller", {
   expect_equal(x$schedule$summary()$pushed, 0L)
   expect_equal(x$schedule$summary()$collected, 1L)
 })
-
-crew_test("launch_max", {
-  skip_on_cran()
-  skip_on_os("windows")
-  x <- crew_controller_local(
-    workers = 1L,
-    seconds_idle = 1e-9,
-    launch_max = 5L
-  )
-  on.exit({
-    x$terminate()
-    rm(x)
-    gc()
-    crew_test_sleep()
-  })
-  x$start()
-  for (index in seq_len(5L)) {
-    x$launch(n = 1L)
-    crew_retry(
-      ~!x$launcher$workers$handle[[1L]]$is_alive(),
-      seconds_interval = 0.05,
-    )
-  }
-  expect_crew_error(x$launch(n = 1L))
-})

--- a/tests/testthat/test-crew_controller_local.R
+++ b/tests/testthat/test-crew_controller_local.R
@@ -536,3 +536,28 @@ crew_test("map() does not need an empty controller", {
   expect_equal(x$schedule$summary()$pushed, 0L)
   expect_equal(x$schedule$summary()$collected, 1L)
 })
+
+crew_test("launch_max", {
+  skip_on_cran()
+  skip_on_os("windows")
+  x <- crew_controller_local(
+    workers = 1L,
+    seconds_idle = 1e-9,
+    launch_max = 5L
+  )
+  on.exit({
+    x$terminate()
+    rm(x)
+    gc()
+    crew_test_sleep()
+  })
+  x$start()
+  for (index in seq_len(5L)) {
+    x$launch(n = 1L)
+    crew_retry(
+      ~!x$launcher$workers$handle[[1L]]$is_alive(),
+      seconds_interval = 0.05,
+    )
+  }
+  expect_crew_error(x$launch(n = 1L))
+})

--- a/tests/testthat/test-crew_launcher.R
+++ b/tests/testthat/test-crew_launcher.R
@@ -148,7 +148,9 @@ crew_test("launcher start()", {
       "socket",
       "start",
       "launches",
+      "futile",
       "launched",
+      "history",
       "assigned",
       "complete"
     )
@@ -298,7 +300,8 @@ crew_test("custom launcher", {
     reset_globals = TRUE,
     reset_packages = FALSE,
     reset_options = FALSE,
-    garbage_collection = FALSE
+    garbage_collection = FALSE,
+    launch_max = 5L
   ) {
     client <- crew::crew_client(
       name = name,
@@ -322,7 +325,8 @@ crew_test("custom launcher", {
       reset_globals = reset_globals,
       reset_packages = reset_packages,
       reset_options = reset_options,
-      garbage_collection = garbage_collection
+      garbage_collection = garbage_collection,
+      launch_max = launch_max
     )
     controller <- crew::crew_controller(
       client = client,

--- a/vignettes/plugins.Rmd
+++ b/vignettes/plugins.Rmd
@@ -88,7 +88,7 @@ Every `launch_worker()` method must accept arguments `call`, `launcher`, `worker
 
 To see what the `call` object looks like, create a new launcher and run the `call()` method.
 
-```{r, eval = TRUE}
+```{r, eval = TRUE, message = FALSE}
 library(crew)
 launcher <- crew_launcher_local()
 launcher$call(
@@ -135,7 +135,8 @@ crew_controller_custom <- function(
   reset_globals = TRUE,
   reset_packages = FALSE,
   reset_options = FALSE,
-  garbage_collection = FALSE
+  garbage_collection = FALSE,
+  launch_max = 5L
 ) {
   client <- crew::crew_client(
     name = name,
@@ -159,7 +160,8 @@ crew_controller_custom <- function(
     reset_globals = reset_globals,
     reset_packages = reset_packages,
     reset_options = reset_options,
-    garbage_collection = garbage_collection
+    garbage_collection = garbage_collection,
+    launch_max = launch_max
   )
   controller <- crew::crew_controller(client = client, launcher = launcher)
   controller$validate()


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [Contributor Code of Conduct](https://github.com/wlandau/crew/blob/main/CODE_OF_CONDUCT.md).
* [x] I have already submitted a [discussion topic](https://github.com/ropensci/crew/discussions) or [issue](https://github.com/ropensci/crew/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #101

# Summary

This PR implements a new `launch_max` argument to the controllers and launchers which sets the maximum number of allowed launch attempts in a row which do not complete any tasks. @shikokuchuo suggested this as a robust uniform solution to https://github.com/wlandau/crew.cluster/issues/19 and https://github.com/shikokuchuo/mirai/issues/20. Indeed it prevents a nightmare of indefinitely racking up costs on a malfunctioning platform, but given https://github.com/wlandau/crew/issues/79, `launch_max` can almost never be zero. So at best, this PR is only an approximate solution. I hope there is a more precise / less wasteful way to solve this long-term. Maybe it will have to involve understanding why some workers become backlogged in the first place and to prevent that outcome entirely.

FYI @multimeric
