### PR TITLE
Small test amendments

### DIFF
--- a/tests/mirai/test-tls-persistent.R
+++ b/tests/mirai/test-tls-persistent.R
@@ -12,7 +12,7 @@ schedule$start()
 # Start the {mirai} client and servers with TLS.
 daemons(n = 20L, url = "wss://127.0.0.1:0", dispatcher = TRUE, token = TRUE)
 for (url in environment(daemons)$..$default$urls) {
-  launch_server(url = url)
+  launch_local(url = url)
   Sys.sleep(0.1)
 }
 

--- a/tests/testthat/test-crew_client.R
+++ b/tests/testthat/test-crew_client.R
@@ -60,11 +60,11 @@ crew_test("crew_client() works", {
   )
   m <- mirai::mirai(ps::ps_pid(), .compute = client$name)
   crew_retry(
-    ~!anyNA(m$data),
+    ~!.unresolved(m),
     seconds_interval = 0.5,
     seconds_timeout = 10
   )
-  expect_false(anyNA(m$data))
+  expect_false(.unresolved(m))
   expect_true(is.numeric(m$data))
   expect_true(abs(m$data - ps::ps_pid()) > 0.5)
   expect_true(client$started)

--- a/tests/testthat/test-crew_launcher_local.R
+++ b/tests/testthat/test-crew_launcher_local.R
@@ -49,7 +49,7 @@ crew_test("crew_launcher_local() can run a task on a worker", {
   expect_equal(launcher$workers$launches, c(0L, 1L, 0L, 0L))
   m <- mirai::mirai(ps::ps_pid(), .compute = client$name)
   crew_retry(
-    ~!anyNA(m$data),
+    ~!.unresolved(m),
     seconds_interval = 0.5,
     seconds_timeout = 10
   )
@@ -104,7 +104,7 @@ crew_test("crew_launcher_local() can run a task and time out a worker", {
   )
   m <- mirai::mirai(ps::ps_pid(), .compute = client$name)
   crew::crew_retry(
-    ~!anyNA(m$data),
+    ~!.unresolved(m),
     seconds_interval = 0.1,
     seconds_timeout = 5
   )


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [Contributor Code of Conduct](https://github.com/wlandau/crew/blob/main/CODE_OF_CONDUCT.md).
* [ ] I have already submitted a [discussion topic](https://github.com/ropensci/crew/discussions) or [issue](https://github.com/ropensci/crew/issues) to discuss my idea with the maintainer.

# Summary

One case of a function name update. The others are just to ensure that the resolved status of a `mirai` is checked by either  `unresolved()` or `.unresolved()`, rather than by relying on the internal structure of an `unresolvedValue`, which is subject to change in future versions (may no longer be NAs).