### PR TITLE
remove launch_max so that example runs

### DIFF
--- a/vignettes/plugins.Rmd
+++ b/vignettes/plugins.Rmd
@@ -135,8 +135,7 @@ crew_controller_custom <- function(
   reset_globals = TRUE,
   reset_packages = FALSE,
   reset_options = FALSE,
-  garbage_collection = FALSE,
-  launch_max = 5L
+  garbage_collection = FALSE
 ) {
   client <- crew::crew_client(
     name = name,
@@ -160,8 +159,7 @@ crew_controller_custom <- function(
     reset_globals = reset_globals,
     reset_packages = reset_packages,
     reset_options = reset_options,
-    garbage_collection = garbage_collection,
-    launch_max = launch_max
+    garbage_collection = garbage_collection
   )
   controller <- crew::crew_controller(client = client, launcher = launcher)
   controller$validate()


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [Contributor Code of Conduct](https://github.com/wlandau/crew/blob/main/CODE_OF_CONDUCT.md).
* [ ] I have already submitted a [discussion topic](https://github.com/ropensci/crew/discussions) or [issue](https://github.com/ropensci/crew/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

I did not open a discussion topic because the change is small and simple.

# Summary

The `launch_max` argument causes the example to fail.  I think that it is due to copying and pasting from `crew_controller_local()`.