### PR TITLE
Small changes for argument name in latest mirai

### DIFF
--- a/R/crew_launcher.R
+++ b/R/crew_launcher.R
@@ -707,7 +707,7 @@ crew_class_launcher <- R6::R6Class(
           "https://wlandau.github.io/crew/articles/risks.html#crashes"
         )
       )
-      mirai::call_mirai_(aio = private$.workers$handle[[index]])
+      mirai::call_mirai_(private$.workers$handle[[index]])
       handle <- self$launch_worker(
         call = as.character(call),
         name = as.character(name),
@@ -870,7 +870,7 @@ crew_class_launcher <- R6::R6Class(
       for (worker in index) {
         if (!workers$terminated[worker]) {
           handle <- workers$handle[[worker]]
-          mirai::call_mirai_(aio = handle)
+          mirai::call_mirai_(handle)
           private$.workers$termination[[worker]] <-
             self$terminate_worker(handle = handle) %|||% crew_null
         }


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [Contributor Code of Conduct](https://github.com/wlandau/crew/blob/main/CODE_OF_CONDUCT.md).
* [ ] I have already submitted a [discussion topic](https://github.com/wlandau/crew/discussions) or [issue](https://github.com/wlandau/crew/issues) to discuss my idea with the maintainer.

# Summary

In two places you use `call_mirai_` with the argument 'aio'.

Whilst I have ignored the aesthetics until now, I am now making the arguments consistent between `nanonext` and `mirai` as the use of 'aio' in `mirai` may be confusing and this is now just a generic 'x'. This comes about as I directly assign the functions from `nanonext` in `mirai` to avoid an additional R function call.

As this function will only ever take one argument, I'd think it's both practically and stylistically fine to call without the argument name.

This change will need to be on CRAN before I make the next `mirai` release. Thanks!