### PR TITLE
tests: switch base64 to secretbase

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,6 +60,7 @@ Suggests:
   knitr (>= 1.30),
   markdown (>= 1.1),
   rmarkdown (>= 2.4),
+  secretbase (>= 1.0.0),
   testthat (>= 3.0.0)
 Encoding: UTF-8
 Language: en-US

--- a/tests/testthat/test-crew_controller_local.R
+++ b/tests/testthat/test-crew_controller_local.R
@@ -115,13 +115,13 @@ crew_test("crew_controller_local()", {
     expect_false(exists(x = ".crew_y", envir = globalenv()))
     # package task
     x$push(
-      command = base64enc(arg),
+      command = secretbase::base64enc(arg),
       data = list(arg = "x"),
       packages = "nanonext"
     )
     x$wait(seconds_timeout = 5)
     out <- x$pop()
-    expect_equal(out$result[[1]], nanonext::base64enc("x"))
+    expect_equal(out$result[[1]], secretbase::base64enc("x"))
   }
   # terminate
   handle <- x$launcher$workers$handle[[1]]


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [Contributor Code of Conduct](https://github.com/wlandau/crew/blob/main/CODE_OF_CONDUCT.md).
* [ ] I have already submitted a [discussion topic](https://github.com/wlandau/crew/discussions) or [issue](https://github.com/wlandau/crew/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #

# Summary

There is a test that was using `nanonext::base64()`.

Base64 is being retired from `nanonext` as the final part of moving out general utility functions, refocusing it more tightly on being a communications package.

These functions were added recently to v1.0.0 of `secretbase`, completing the scope of that package.

This PR fixes the test, but takes in `secretbase` as a soft dependency. Feel free, if you wish, to not merge this PR but modify the test to use something else instead.