### PR TITLE
Avoid mirai daemons deprecated dispatcher option

### DIFF
--- a/tests/local/test-tls.R
+++ b/tests/local/test-tls.R
@@ -30,7 +30,7 @@ crew_test("mirai client can start using custom credentials", {
     tmp <- mirai::daemons(
       n = 1L,
       url = "wss://127.0.0.1:0",
-      dispatcher = "process",
+      dispatcher = TRUE,
       seed = NULL,
       tls = c(
         paste(readLines("fd.crt"), collapse = "\n"),

--- a/tests/testthat/test-crew_monitor_local.R
+++ b/tests/testthat/test-crew_monitor_local.R
@@ -3,7 +3,7 @@ crew_test("monitor dispatchers", {
   skip_on_os("windows")
   x <- crew_monitor_local()
   expect_true(is.integer(x$dispatchers()))
-  mirai::daemons(n = 1L, dispatcher = "process")
+  mirai::daemons(n = 1L, dispatcher = TRUE)
   on.exit({
     mirai::daemons(n = 0L)
     gc()


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [Contributor Code of Conduct](https://github.com/wlandau/crew/blob/main/CODE_OF_CONDUCT.md).

# Summary

I came across this in revdep testing. No hurry for this, I'll just keep it around for a bit longer.