### PR TITLE
Make all non-launcher R6 classes non-portable

### DIFF
--- a/R/crew_controller.R
+++ b/R/crew_controller.R
@@ -543,11 +543,11 @@ crew_class_controller <- R6::R6Class(
       }
       poll <- function() {
         if (isTRUE(.client$started) && isTRUE(.autoscaling)) {
-          scale(throttle = FALSE)
+          self$scale(throttle = FALSE) # necessary reference to self
           later::later(func = poll, delay = .client$seconds_interval)
         }
       }
-      start()
+      self$start() # necessary reference to self
       .autoscaling <<- TRUE
       poll()
       invisible()

--- a/R/crew_controller.R
+++ b/R/crew_controller.R
@@ -92,7 +92,7 @@ crew_controller <- function(
 #' @details See [crew_controller()].
 #' @examples
 #' if (identical(Sys.getenv("CREW_EXAMPLES"), "true")) {
-#' client <- crew_client()
+#' client <- crew_client() d
 #' launcher <- crew_launcher_local()
 #' controller <- crew_controller(client = client, launcher = launcher)
 #' controller$start()
@@ -238,71 +238,71 @@ crew_class_controller <- R6::R6Class(
   active = list(
     #' @field client Client object.
     client = function() {
-      .subset2(private, ".client")
+      .client
     },
     #' @field launcher Launcher object.
     launcher = function() {
-      .subset2(private, ".launcher")
+      .launcher
     },
     #' @field tasks A list of `mirai::mirai()` task objects.
     tasks = function() {
-      .subset2(private, ".tasks")
+      .tasks
     },
     #' @field pushed Number of tasks pushed since the controller was started.
     pushed = function() {
-      .subset2(private, ".pushed")
+      .pushed
     },
     #' @field popped Number of tasks popped
     #' since the controller was started.
     popped = function() {
-      .subset2(private, ".popped")
+      .popped
     },
     #' @field reset_globals See [crew_controller()].
     #' since the controller was started.
     reset_globals = function() {
-      .subset2(private, ".reset_globals")
+      .reset_globals
     },
     #' @field reset_packages See [crew_controller()].
     #' since the controller was started.
     reset_packages = function() {
-      .subset2(private, ".reset_packages")
+      .reset_packages
     },
     #' @field reset_options See [crew_controller()].
     #' since the controller was started.
     reset_options = function() {
-      .subset2(private, ".reset_options")
+      .reset_options
     },
     #' @field garbage_collection See [crew_controller()].
     #' since the controller was started.
     garbage_collection = function() {
-      .subset2(private, ".garbage_collection")
+      .garbage_collection
     },
     #' @field crashes_max See [crew_controller()].
     crashes_max = function() {
-      .subset2(private, ".crashes_max")
+      .crashes_max
     },
     #' @field backup See [crew_controller()].
     backup = function() {
-      .subset2(private, ".backup")
+      .backup
     },
     #' @field error Tibble of task results (with one result per row)
     #'   from the last call to `map(error = "stop)`.
     error = function() {
-      .subset2(private, ".error")
+      .error
     },
     #' @field autoscaling `TRUE` or `FALSE`, whether async `later`-based
     #'   auto-scaling is currently running
     autoscaling = function() {
-      .subset2(private, ".autoscaling")
+      .autoscaling
     },
     #' @field queue_resolved Queue of resolved unpopped/uncollected tasks.
     queue_resolved = function() {
-      .subset2(private, ".queue_resolved")
+      .queue_resolved
     },
     #' @field queue_backlog A [crew_queue()] object tracking explicitly
     #'   backlogged tasks.
     queue_backlog = function() {
-      .subset2(private, ".queue_backlog")
+      .queue_backlog
     }
   ),
   public = list(
@@ -337,23 +337,23 @@ crew_class_controller <- R6::R6Class(
       crashes_max = NULL,
       backup = NULL
     ) {
-      private$.client <- client
-      private$.launcher <- launcher
-      private$.reset_globals <- reset_globals
-      private$.reset_packages <- reset_packages
-      private$.reset_options <- reset_options
-      private$.garbage_collection <- garbage_collection
-      private$.crashes_max <- crashes_max
-      private$.backup <- backup
+      .client <<- client
+      .launcher <<- launcher
+      .reset_globals <<- reset_globals
+      .reset_packages <<- reset_packages
+      .reset_options <<- reset_options
+      .garbage_collection <<- garbage_collection
+      .crashes_max <<- crashes_max
+      .backup <<- backup
       invisible()
     },
     #' @description Validate the controller.
     #' @return `NULL` (invisibly).
     validate = function() {
-      crew_assert(inherits(private$.client, "crew_class_client"))
-      crew_assert(inherits(private$.launcher, "crew_class_launcher"))
-      private$.client$validate()
-      private$.launcher$validate()
+      crew_assert(inherits(.client, "crew_class_client"))
+      crew_assert(inherits(.launcher, "crew_class_launcher"))
+      .client$validate()
+      .launcher$validate()
       fields <- c(
         "reset_globals",
         "reset_packages",
@@ -368,7 +368,7 @@ crew_class_controller <- R6::R6Class(
         )
       }
       crew_assert(
-        private$.crashes_max,
+        .crashes_max,
         is.numeric(.),
         length(.) == 1L,
         is.finite(.),
@@ -377,12 +377,12 @@ crew_class_controller <- R6::R6Class(
           "crashes_max must be a finite non-negative integer scalar."
         )
       )
-      if (!is.null(private$.crash_log)) {
-        crew_assert(is.environment(private$.crash_log))
+      if (!is.null(.crash_log)) {
+        crew_assert(is.environment(.crash_log))
       }
-      if (!is.null(private$.backup)) {
+      if (!is.null(.backup)) {
         crew_assert(
-          private$.backup,
+          .backup,
           inherits(., "crew_class_controller"),
           !inherits(., "crew_class_controller_group"),
           message = paste(
@@ -391,26 +391,26 @@ crew_class_controller <- R6::R6Class(
           )
         )
         crew_assert(
-          private$.crashes_max > 0L,
+          .crashes_max > 0L,
           message = "crashes_max must be positive if backup is not NULL."
         )
       }
-      crew_assert(private$.tasks, is.null(.) || is.environment(.))
-      crew_assert(private$.summary, is.null(.) || is.list(.))
-      crew_assert(private$.autoscaling, is.null(.) || isTRUE(.) || isFALSE(.))
+      crew_assert(.tasks, is.null(.) || is.environment(.))
+      crew_assert(.summary, is.null(.) || is.list(.))
+      crew_assert(.autoscaling, is.null(.) || isTRUE(.) || isFALSE(.))
       crew_assert(
-        private$.resolved,
+        .resolved,
         is.integer(.),
         length(.) == 1L,
         is.finite(.)
       )
-      if (!is.null(private$.queue_resolved)) {
-        crew_assert(private$.queue_resolved, inherits(., "crew_class_queue"))
-        private$.queue_resolved$validate()
+      if (!is.null(.queue_resolved)) {
+        crew_assert(.queue_resolved, inherits(., "crew_class_queue"))
+        .queue_resolved$validate()
       }
-      if (!is.null(private$.queue_backlog)) {
-        crew_assert(private$.queue_backlog, inherits(., "crew_class_queue"))
-        private$.queue_backlog$validate()
+      if (!is.null(.queue_backlog)) {
+        crew_assert(.queue_backlog, inherits(., "crew_class_queue"))
+        .queue_backlog$validate()
       }
       invisible()
     },
@@ -421,7 +421,7 @@ crew_class_controller <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     empty = function(controllers = NULL) {
-      .subset2(private, ".pushed") == .subset2(private, ".popped")
+      .pushed == .popped
     },
     #' @description Check if the controller is nonempty.
     #' @details A controller is empty if it has no running tasks
@@ -430,7 +430,7 @@ crew_class_controller <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     nonempty = function(controllers = NULL) {
-      .subset2(private, ".pushed") > .subset2(private, ".popped")
+      .pushed > .popped
     },
     #' @description Number of resolved `mirai()` tasks.
     #' @details `resolved()` is cumulative: it counts all the resolved
@@ -442,7 +442,7 @@ crew_class_controller <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     resolved = function(controllers = NULL) {
-      .subset2(.subset2(self, "client"), "resolved")()
+      .subset2(.client, "resolved")()
     },
     #' @description Number of unresolved `mirai()` tasks.
     #' @return Non-negative integer of length 1,
@@ -450,7 +450,7 @@ crew_class_controller <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     unresolved = function(controllers = NULL) {
-      .subset2(private, ".pushed") - .subset2(self, "resolved")()
+      .pushed - resolved()
     },
     #' @description Number of resolved `mirai()` tasks available via `pop()`.
     #' @return Non-negative integer of length 1,
@@ -458,7 +458,7 @@ crew_class_controller <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     unpopped = function(controllers = NULL) {
-      .subset2(self, "resolved")() - .subset2(private, ".popped")
+      resolved() - .popped
     },
     #' @description Check if the controller is saturated.
     #' @details A controller is saturated if the number of unresolved tasks
@@ -473,8 +473,7 @@ crew_class_controller <- R6::R6Class(
     #' @param controller Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     saturated = function(collect = NULL, throttle = NULL, controller = NULL) {
-      .subset2(self, "unresolved")() >=
-        .subset2(.subset2(self, "launcher"), "workers")
+      unresolved() >= .subset2(.launcher, "workers")
     },
     #' @description Start the controller if it is not already started.
     #' @details Register the mirai client and register worker websockets
@@ -483,13 +482,10 @@ crew_class_controller <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     start = function(controllers = NULL) {
-      if (!.subset2(.subset2(self, "client"), "started")) {
-        private$.client$start()
-        private$.launcher$start(
-          url = private$.client$url,
-          profile = private$.client$profile
-        )
-        private$.register_started()
+      if (!.subset2(.client, "started")) {
+        .client$start()
+        .launcher$start(url = .client$url, profile = .client$profile)
+        .register_started()
       }
       invisible()
     },
@@ -499,7 +495,7 @@ crew_class_controller <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     started = function(controllers = NULL) {
-      .subset2(.subset2(self, "client"), "started")
+      .subset2(.client, "started")
     },
     #' @description Launch one or more workers.
     #' @return `NULL` (invisibly).
@@ -507,8 +503,8 @@ crew_class_controller <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     launch = function(n = 1L, controllers = NULL) {
-      self$start()
-      replicate(n, private$.launcher$launch(), simplify = FALSE)
+      start()
+      replicate(n, .launcher$launch(), simplify = FALSE)
       invisible()
     },
     #' @description Auto-scale workers out to meet the demand of tasks.
@@ -524,12 +520,12 @@ crew_class_controller <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     scale = function(throttle = TRUE, controllers = NULL) {
-      if (throttle && !private$.launcher$poll()) {
+      if (throttle && !.launcher$poll()) {
         return(invisible())
       }
-      .subset2(self, "start")()
-      status <- private$.client$status()
-      activity <- private$.launcher$scale(status = status, throttle = throttle)
+      start()
+      status <- .client$status()
+      activity <- .launcher$scale(status = status, throttle = throttle)
       invisible(activity)
     },
     #' @description Run worker auto-scaling in a private `later` loop
@@ -542,17 +538,17 @@ crew_class_controller <- R6::R6Class(
     autoscale = function(controllers = NULL) {
       # Tested in tests/interactive/test-promises.R
       # nocov start
-      if (isTRUE(private$.autoscaling)) {
+      if (isTRUE(.autoscaling)) {
         return(invisible())
       }
       poll <- function() {
-        if (isTRUE(private$.client$started) && isTRUE(private$.autoscaling)) {
-          self$scale(throttle = FALSE)
-          later::later(func = poll, delay = self$client$seconds_interval)
+        if (isTRUE(.client$started) && isTRUE(.autoscaling)) {
+          scale(throttle = FALSE)
+          later::later(func = poll, delay = .client$seconds_interval)
         }
       }
-      self$start()
-      private$.autoscaling <- TRUE
+      start()
+      .autoscaling <<- TRUE
       poll()
       invisible()
       # nocov end
@@ -563,7 +559,7 @@ crew_class_controller <- R6::R6Class(
     #'   compatible with the analogous method of controller groups.
     #' @return `NULL` (invisibly).
     descale = function(controllers = NULL) {
-      private$.autoscaling <- FALSE
+      .autoscaling <<- FALSE
       invisible()
     },
     #' @description Report the number of consecutive crashes of a task.
@@ -574,7 +570,7 @@ crew_class_controller <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     crashes = function(name, controllers = NULL) {
-      count <- .subset2(.subset2(private, ".crash_log"), name)
+      count <- .subset2(.crash_log, name)
       if (is.null(count)) {
         0L
       } else {
@@ -658,8 +654,8 @@ crew_class_controller <- R6::R6Class(
       save_command = NULL,
       controller = NULL
     ) {
-      .subset2(self, "start")()
-      name <- private$.name_new_task(name)
+      start()
+      name <- .name_new_task(name)
       if (substitute) {
         command <- substitute(command)
       }
@@ -668,12 +664,10 @@ crew_class_controller <- R6::R6Class(
       } else {
         .timeout <- seconds_timeout * 1000
       }
-      backup <- .subset2(private, ".backup")
-      if (!is.null(backup)) {
-        max <- .subset2(private, ".crashes_max")
-        if ((max > 0L) && (.subset2(self, "crashes")(name = name) == max)) {
+      if (!is.null(.backup)) {
+        if ((.crashes_max > 0L) && (crashes(name = name) == .crashes_max)) {
           return(
-            .subset2(backup, "push")(
+            .subset2(.backup, "push")(
               command = command,
               data = data,
               globals = globals,
@@ -702,17 +696,17 @@ crew_class_controller <- R6::R6Class(
           algorithm = algorithm,
           packages = packages,
           library = library,
-          reset_globals = .subset2(private, ".reset_globals"),
-          reset_packages = .subset2(private, ".reset_packages"),
-          reset_options = .subset2(private, ".reset_options"),
-          garbage_collection = .subset2(private, ".garbage_collection")
+          reset_globals = .reset_globals,
+          reset_packages = .reset_packages,
+          reset_options = .reset_options,
+          garbage_collection = .garbage_collection
         ),
         .timeout = .timeout,
-        .compute = .subset2(.subset2(private, ".client"), "profile")
+        .compute = .subset2(.client, "profile")
       )
-      .subset2(private, ".register_task")(name, task)
+      .register_task(name, task)
       if (scale) {
-        .subset2(self, "scale")(throttle = throttle)
+        scale(throttle = throttle)
       }
       invisible(task)
     },
@@ -810,7 +804,7 @@ crew_class_controller <- R6::R6Class(
       throttle = TRUE,
       controller = NULL
     ) {
-      .subset2(self, "start")()
+      start()
       crew_deprecate(
         name = "save_command",
         date = "2025-01-22",
@@ -912,7 +906,7 @@ crew_class_controller <- R6::R6Class(
         message = "task names in map() must not have duplicates"
       )
       names_iterate <- names(iterate)
-      self$start()
+      start()
       sign <- if_any(!is.null(seed) && seed > 0L, 1L, -1L)
       if (!is.null(seed)) {
         seed <- 1L
@@ -920,7 +914,6 @@ crew_class_controller <- R6::R6Class(
       total <- length(names)
       tasks <- vector(mode = "list", length = total)
       names(tasks) <- names
-      push <- self$push
       # covered in tests/local/test-map.R
       # nocov start
       if (verbose) {
@@ -978,7 +971,7 @@ crew_class_controller <- R6::R6Class(
       }
       # nocov end
       if (scale) {
-        self$scale(throttle = throttle)
+        scale(throttle = throttle)
       }
       invisible(tasks)
     },
@@ -1119,7 +1112,7 @@ crew_class_controller <- R6::R6Class(
         value = save_command
       )
       crew_assert(
-        length(private$.tasks) < 1L,
+        length(.tasks) < 1L,
         message = "cannot map() until all prior tasks are completed and popped"
       )
       crew_assert(substitute, isTRUE(.) || isFALSE(.))
@@ -1127,7 +1120,7 @@ crew_class_controller <- R6::R6Class(
       if (substitute) {
         command <- substitute(command)
       }
-      tasks <- self$walk(
+      tasks <- walk(
         command = command,
         iterate = iterate,
         data = data,
@@ -1144,9 +1137,8 @@ crew_class_controller <- R6::R6Class(
       )
       names <- names(tasks)
       total <- length(tasks)
-      relay <- .subset2(.subset2(self, "client"), "relay")
+      relay <- .subset2(.client, "relay")
       start <- nanonext::mclock()
-      pushed <- private$.pushed
       if (verbose) {
         this_envir <- environment()
         progress_envir <- new.env(parent = this_envir)
@@ -1165,9 +1157,9 @@ crew_class_controller <- R6::R6Class(
       }
       iterate <- function() {
         if (scale) {
-          .subset2(self, "scale")(throttle = throttle)
+          scale(throttle = throttle)
         }
-        unresolved <- .subset2(self, "unresolved")()
+        unresolved <- unresolved()
         if (verbose) {
           cli::cli_progress_update(
             set = total - unresolved,
@@ -1178,7 +1170,7 @@ crew_class_controller <- R6::R6Class(
         if (unresolved > 0L) {
           .subset2(relay, "wait")()
         }
-        .subset2(self, "unresolved")() < 1L
+        unresolved() < 1L
       }
       crew_retry(
         fun = iterate,
@@ -1191,7 +1183,7 @@ crew_class_controller <- R6::R6Class(
         cli::cli_progress_done(id = bar, .envir = progress_envir)
       }
       out <- vector(mode = "list", length = total)
-      controller_name <- .subset2(.subset2(private, ".launcher"), "name")
+      controller_name <- .subset2(.launcher, "name")
       index <- 1L
       while (index <= total) {
         task <- .subset2(tasks, index)
@@ -1201,7 +1193,7 @@ crew_class_controller <- R6::R6Class(
           name = name,
           controller = controller_name
         )
-        .subset2(private, ".scan_crash")(name = name, task = monad)
+        .scan_crash(name = name, task = monad)
         out[[index]] <- monad
         index <- index + 1L
       }
@@ -1209,19 +1201,17 @@ crew_class_controller <- R6::R6Class(
       out <- out[match(x = names, table = out$name), , drop = FALSE] # nolint
       out <- out[!is.na(out$name), , drop = FALSE] # nolint
       on.exit({
-        private$.tasks <- new.env(parent = emptyenv(), hash = TRUE)
-        private$.popped <- .subset2(private, ".popped") + nrow(out)
-        summary <- private$.summary
-        summary$tasks <- .subset2(summary, "tasks") + nrow(out)
-        summary$seconds <- .subset2(summary, "seconds") +
+        .tasks <<- new.env(parent = emptyenv(), hash = TRUE)
+        .popped <<- .popped + nrow(out)
+        .summary$tasks <<- .subset2(.summary, "tasks") + nrow(out)
+        .summary$seconds <<- .subset2(.summary, "seconds") +
           sum(out$seconds)
         for (status in c("success", "error", "crash", "cancel")) {
-          summary[[status]] <- .subset2(summary, status) +
+          .summary[[status]] <<- .subset2(.summary, status) +
             sum(.subset2(out, "status") == status)
         }
-        summary$warning <- .subset2(summary, "warning") +
+        .summary$warning <<- .subset2(.summary, "warning") +
           sum(!is.na(out$warnings))
-        private$.summary <- summary
       })
       warning_messages <- out$warnings
       if (!all(is.na(warning_messages)) && isTRUE(warnings)) {
@@ -1243,7 +1233,7 @@ crew_class_controller <- R6::R6Class(
           error_messages[min(which(!is.na(error_messages)))]
         )
         if (identical(error, "stop")) {
-          private$.error <- out
+          .error <<- out
           message <- paste(
             message,
             "\nSee the \"error\" field of your controller object",
@@ -1329,7 +1319,7 @@ crew_class_controller <- R6::R6Class(
       error = NULL,
       controllers = NULL
     ) {
-      if (!.subset2(.subset2(self, "client"), "started")) {
+      if (!.subset2(.client, "started")) {
         return(NULL)
       }
       crew_deprecate(
@@ -1353,42 +1343,39 @@ crew_class_controller <- R6::R6Class(
         )
       }
       if (scale) {
-        .subset2(self, "scale")(throttle = throttle)
+        scale(throttle = throttle)
       }
-      if (.subset2(self, "empty")()) {
+      if (empty()) {
         return(NULL)
       }
-      .subset2(private, ".resolve")(force = FALSE)
-      name <- .subset2(.subset2(private, ".queue_resolved"), "pop")()
+      .resolve(force = FALSE)
+      name <- .subset2(.queue_resolved, "pop")()
       if (is.null(name)) {
         return(NULL)
       }
-      tasks <- .subset2(self, "tasks")
-      task <- .subset2(tasks, name)
+      task <- .subset2(.tasks, name)
       remove(list = name, envir = tasks)
-      private$.popped <- .subset2(self, "popped") + 1L
+      .popped <<- .popped + 1L
       out <- as_monad(
         task = task,
         name = name,
-        controller = .subset2(.subset2(private, ".launcher"), "name")
+        controller = .subset2(.launcher, "name")
       )
       suppressWarnings({
-        .subset2(private, ".scan_crash")(name = name, task = out)
+        .scan_crash(name = name, task = out)
+        .summary$tasks <<- .subset2(.summary, "tasks") + 1L
         seconds <- .subset2(out, "seconds")
-        summary <- .subset2(private, ".summary")
-        summary$tasks <- .subset2(summary, "tasks") + 1L
         if (!anyNA(seconds)) {
-          summary$seconds <- .subset2(summary, "seconds") + seconds
+          .summary$seconds <<- .subset2(.summary, "seconds") + seconds
         }
       })
       status <- .subset2(out, "status")
-      summary[[status]] <- .subset2(summary, status) + 1L
+      .summary[[status]] <<- .subset2(.summary, status) + 1L
       if (!anyNA(.subset2(out, "warnings"))) {
         # Tests definitely cover this line, but for some reason
         # the code coverage CI workflow does not detect it.
-        summary$warning <- .subset2(summary, "warning") + 1L # nocov
+        .summary$warning <<- .subset2(.summary, "warning") + 1L # nocov
       }
-      private$.summary <- summary
       if (!is.null(error)) {
         has_error <- any(status != "success")
         throw_error <- has_error && all(error == "stop")
@@ -1449,44 +1436,40 @@ crew_class_controller <- R6::R6Class(
         )
       }
       if (scale) {
-        .subset2(self, "scale")(throttle = throttle)
+        scale(throttle = throttle)
       }
-      if (.subset2(self, "empty")()) {
+      if (empty()) {
         return(NULL)
       }
-      queue <- .subset2(private, ".queue_resolved")
-      .subset2(private, ".resolve")(force = TRUE)
-      names <- .subset2(queue, "collect")()
+      .resolve(force = TRUE)
+      names <- .subset2(.queue_resolved, "collect")()
       if (!length(names)) {
         return(NULL)
       }
-      tasks <- .subset2(private, ".tasks")
-      scan_crash <- .subset2(private, ".scan_crash")
-      controller_name <- .subset2(.subset2(private, ".launcher"), "name")
+      controller_name <- .subset2(.launcher, "name")
       out <- lapply(names, function(name) {
         out <- as_monad(
-          task = .subset2(tasks, name),
+          task = .subset2(.tasks, name),
           name = name,
           controller = controller_name
         )
-        scan_crash(name = name, task = out)
+        .scan_crash(name = name, task = out)
         out
       })
       out <- tibble::new_tibble(data.table::rbindlist(out, use.names = FALSE))
-      remove(list = names, envir = tasks)
-      popped <- length(names)
-      private$.popped <- .subset2(self, "popped") + popped
-      summary <- .subset2(private, ".summary")
-      summary$tasks <- .subset2(summary, "tasks") + popped
-      summary$seconds <- .subset2(summary, "seconds") +
+      remove(list = names, envir = .tasks)
+      new_popped <- length(names)
+      .popped <<- .popped + new_popped
+
+      .summary$tasks <<- .subset2(.summary, "tasks") + new_popped
+      .summary$seconds <<- .subset2(.summary, "seconds") +
         sum(.subset2(out, "seconds"), na.rm = TRUE)
       for (status in c("success", "error", "crash", "cancel")) {
-        summary[[status]] <- .subset2(summary, status) +
+        .summary[[status]] <<- .subset2(.summary, status) +
           sum(.subset2(out, "status") == status)
       }
-      summary$warning <- .subset2(summary, "warning") +
+      .summary$warning <<- .subset2(.summary, "warning") +
         sum(!is.na(.subset2(out, "warnings")))
-      private$.summary <- summary
       errors <- .subset2(out, "error")
       errors <- errors[!is.na(errors)]
       if (!is.null(error) && length(errors)) {
@@ -1568,7 +1551,7 @@ crew_class_controller <- R6::R6Class(
         value = TRUE,
         frequency = "once"
       )
-      self$autoscale(controllers = controllers)
+      autoscale(controllers = controllers)
       controller_promise(
         controller = self,
         mode = mode,
@@ -1619,20 +1602,16 @@ crew_class_controller <- R6::R6Class(
       )
       crew_assert(mode, identical(., "all") || identical(., "one"))
       mode_all <- identical(mode, "all")
-      if (length(private$.tasks) < 1L) {
+      if (length(.tasks) < 1L) {
         return(invisible(mode_all))
       }
       envir <- new.env(parent = emptyenv())
       envir$result <- FALSE
       iterate <- function() {
         if (!envir$result && scale) {
-          self$scale(throttle = throttle)
+          scale(throttle = throttle)
         }
-        envir$result <- if_any(
-          mode_all,
-          private$.wait_all_once(),
-          private$.wait_one_once()
-        )
+        envir$result <- if_any(mode_all, .wait_all_once(), .wait_one_once())
         envir$result
       }
       crew_retry(
@@ -1653,7 +1632,7 @@ crew_class_controller <- R6::R6Class(
     #' @param controller Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     push_backlog = function(name, controller = NULL) {
-      .subset2(.subset2(private, ".queue_backlog"), "push")(name)
+      .subset2(.queue_backlog, "push")(name)
       invisible()
     },
     #' @description Pop the task names from the head of the backlog which
@@ -1664,13 +1643,11 @@ crew_class_controller <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     pop_backlog = function(controllers = NULL) {
-      n <- .subset2(.subset2(self, "launcher"), "workers") -
-        .subset2(self, "unresolved")()
-      backlog <- .subset2(private, ".queue_backlog")
-      if (n < 1L || .subset2(backlog, "empty")()) {
+      n <- .subset2(.launcher, "workers") - unresolved()
+      if (n < 1L || .subset2(.queue_backlog, "empty")()) {
         return(character(0L))
       }
-      .subset2(backlog, "pop")(n)
+      .subset2(.queue_backlog, "pop")(n)
     },
     #' @description Summarize the workers and tasks of the controller.
     #' @return A data frame of summary statistics on the tasks
@@ -1692,11 +1669,7 @@ crew_class_controller <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     summary = function(controllers = NULL) {
-      out <- .subset2(private, ".summary")
-      if (!is.null(out)) {
-        out <- tibble::new_tibble(out)
-      }
-      out
+      if_any(is.null(.summary), NULL, tibble::new_tibble(.summary))
     },
     #' @description Cancel one or more tasks.
     #' @return `NULL` (invisibly).
@@ -1720,13 +1693,12 @@ crew_class_controller <- R6::R6Class(
           "with no missing or empty strings"
         )
       )
-      tasks <- .subset2(private, ".tasks")
       if (all) {
-        mirai::stop_mirai(as.list(tasks))
+        mirai::stop_mirai(as.list(.tasks))
       }
-      names <- intersect(names, names(tasks))
+      names <- intersect(names, names(.tasks))
       for (name in names) {
-        mirai::stop_mirai(.subset2(tasks, name))
+        mirai::stop_mirai(.subset2(.tasks, name))
       }
       invisible()
     },
@@ -1737,7 +1709,7 @@ crew_class_controller <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     pids = function(controllers = NULL) {
-      private$.client$pids()
+      .client$pids()
     },
     #' @description Terminate the workers and the `mirai` client.
     #' @return `NULL` (invisibly).
@@ -1748,21 +1720,21 @@ crew_class_controller <- R6::R6Class(
       if_any(
         condition = isTRUE(as.logical(Sys.getenv("R_COVR", "false"))),
         true = {
-          private$.launcher$terminate()
-          private$.client$terminate()
+          .launcher$terminate()
+          .client$terminate()
         },
         false = {
-          private$.client$terminate() # nocov
-          private$.launcher$terminate() # nocov
+          .client$terminate() # nocov
+          .launcher$terminate() # nocov
         }
       )
-      private$.tasks <- new.env(parent = emptyenv(), hash = TRUE)
-      private$.pushed <- 0L
-      private$.popped <- 0L
-      private$.crash_log <- new.env(parent = emptyenv(), hash = TRUE)
-      private$.autoscaling <- FALSE
-      private$.queue_resolved <- crew_queue()
-      private$.resolved <- -1L
+      .tasks <<- new.env(parent = emptyenv(), hash = TRUE)
+      .pushed <<- 0L
+      .popped <<- 0L
+      .crash_log <<- new.env(parent = emptyenv(), hash = TRUE)
+      .autoscaling <<- FALSE
+      .queue_resolved <<- crew_queue()
+      .resolved <<- -1L
       invisible()
     }
   )

--- a/R/crew_controller_sequential.R
+++ b/R/crew_controller_sequential.R
@@ -54,9 +54,9 @@ crew_class_controller_sequential <- R6::R6Class(
     #' @param controllers Not used. Included to ensure the signature is
     #'   compatible with the analogous method of controller groups.
     start = function(controllers = NULL) {
-      if (!.subset2(.subset2(self, "client"), "started")) {
-        private$.client$set_started()
-        private$.register_started()
+      if (!.subset2(.client, "started")) {
+        .client$set_started()
+        .register_started()
       }
       invisible()
     },
@@ -158,8 +158,8 @@ crew_class_controller_sequential <- R6::R6Class(
       save_command = NULL,
       controller = NULL
     ) {
-      .subset2(self, "start")()
-      name <- private$.name_new_task(name)
+      start()
+      name <- .name_new_task(name)
       if (substitute) {
         command <- substitute(command)
       }
@@ -178,9 +178,8 @@ crew_class_controller_sequential <- R6::R6Class(
         ),
         class = "mirai"
       )
-      .subset2(private, ".register_task")(name, task)
-      client <- .subset2(private, ".client")
-      nanonext::cv_signal(.subset2(client, "condition"))
+      .register_task(name, task)
+      nanonext::cv_signal(.subset2(.client, "condition"))
       invisible(task)
     },
     #' @description Not applicable to the sequential controller.

--- a/R/crew_controller_sequential.R
+++ b/R/crew_controller_sequential.R
@@ -45,6 +45,7 @@ crew_class_controller_sequential <- R6::R6Class(
   classname = "crew_class_controller_sequential",
   inherit = crew_class_controller,
   cloneable = FALSE,
+  portable = FALSE,
   public = list(
     #' @description Start the controller if it is not already started.
     #' @details For the sequential controller, there is nothing to do

--- a/R/crew_launcher.R
+++ b/R/crew_launcher.R
@@ -646,7 +646,7 @@ crew_class_launcher <- R6::R6Class(
       lost <- !active & !discovered
       handles <- instances$handle[lost]
       handles <- lapply(handles, mirai_resolve, launching = TRUE)
-      mirai_wait(map(handles, self$terminate_worker), launching = FALSE)
+      mirai_wait(lapply(handles, self$terminate_worker), launching = FALSE)
       private$.instances <- instances[active, ]
       invisible()
     },

--- a/R/crew_launcher_local.R
+++ b/R/crew_launcher_local.R
@@ -165,7 +165,8 @@ crew_launcher_local <- function(
 crew_class_launcher_local <- R6::R6Class(
   classname = "crew_class_launcher_local",
   inherit = crew_class_launcher,
-  cloneable = FALSE,
+  cloneable = TRUE,
+  portable = TRUE
   private = list(
     .options_local = NULL,
     .log_prepare = function() {

--- a/R/crew_monitor_local.R
+++ b/R/crew_monitor_local.R
@@ -63,7 +63,7 @@ crew_class_monitor_local <- R6::R6Class(
     #' @param pids Integer vector of process IDs of local processes to
     #'   terminate.
     terminate = function(pids) {
-      walk(as.integer(pids), crew_terminate_process)
+      lapply(as.integer(pids), crew_terminate_process)
     }
   )
 )

--- a/R/crew_throttle.R
+++ b/R/crew_throttle.R
@@ -65,6 +65,7 @@ crew_throttle <- function(
 crew_class_throttle <- R6::R6Class(
   classname = "crew_class_throttle",
   cloneable = FALSE,
+  portable = FALSE,
   private = list(
     .seconds_max = NULL,
     .seconds_min = NULL,
@@ -76,29 +77,29 @@ crew_class_throttle <- R6::R6Class(
   active = list(
     #' @field seconds_max See [crew_throttle()].
     seconds_max = function() {
-      .subset2(private, ".seconds_max")
+      .seconds_max
     },
     #' @field seconds_min See [crew_throttle()].
     seconds_min = function() {
-      .subset2(private, ".seconds_min")
+      .seconds_min
     },
     #' @field seconds_start See [crew_throttle()].
     seconds_start = function() {
-      .subset2(private, ".seconds_start")
+      .seconds_start
     },
     #' @field base See [crew_throttle()].
     base = function() {
-      .subset2(private, ".base")
+      .base
     },
     #' @field seconds_interval Current wait time interval.
     seconds_interval = function() {
-      .subset2(private, ".seconds_interval")
+      .seconds_interval
     },
     #' @field polled Positive numeric of length 1,
     #'  millisecond timestamp of the last time `poll()` returned `TRUE`.
     #'  `NULL` if `poll()` was never called on the current object.
     polled = function() {
-      .subset2(private, ".polled")
+      .polled
     }
   ),
   public = list(
@@ -118,10 +119,10 @@ crew_class_throttle <- R6::R6Class(
       seconds_start = NULL,
       base = NULL
     ) {
-      private$.seconds_max <- seconds_max
-      private$.seconds_min <- seconds_min
-      private$.seconds_start <- seconds_start
-      private$.base <- base
+      .seconds_max <<- seconds_max
+      .seconds_min <<- seconds_min
+      .seconds_start <<- seconds_start
+      .base <<- base
     },
     #' @description Validate the object.
     #' @return `NULL` (invisibly).
@@ -141,11 +142,11 @@ crew_class_throttle <- R6::R6Class(
         )
       }
       crew_assert(
-        self$base > 1,
+        .base > 1,
         message = "crew throttle base must be greater than 1."
       )
       crew_assert(
-        self$polled,
+        .polled,
         is.numeric(.),
         length(.) == 1L,
         !anyNA(.),
@@ -154,7 +155,7 @@ crew_class_throttle <- R6::R6Class(
         )
       )
       crew_assert(
-        self$seconds_min <= self$seconds_max,
+        .seconds_min <= .seconds_max,
         message = paste(
           "crew throttle seconds_min must be",
           "less than or equal to seconds_max."
@@ -162,8 +163,8 @@ crew_class_throttle <- R6::R6Class(
       )
       for (field in c("seconds_start", "seconds_interval")) {
         crew_assert(
-          self$seconds_min <= self[[field]] &&
-            self[[field]] <= self$seconds_max,
+          .seconds_min <= self[[field]] &&
+            self[[field]] <= .seconds_max,
           message = paste(
             "crew throttle",
             field,
@@ -178,38 +179,30 @@ crew_class_throttle <- R6::R6Class(
     #'   `max` seconds, `FALSE` otherwise.
     poll = function() {
       now <- now()
-      polled <- .subset2(private, ".polled")
-      interval <- .subset2(private, ".seconds_interval")
-      out <- (now - polled) > interval
+      out <- (now - .polled) > .seconds_interval
       if (out) {
-        private$.polled <- now
+        .polled <<- now
       }
       out
     },
     #' @description Divide `seconds_interval` by `base`.
     #' @return `NULL` (invisibly). Called for its side effects.
     accelerate = function() {
-      old <- .subset2(private, ".seconds_interval")
-      base <- .subset2(private, ".base")
-      min <- .subset2(private, ".seconds_min")
-      private$.seconds_interval <- max(min, old / base)
+      .seconds_interval <<- max(.seconds_min, .seconds_interval / .base)
       invisible()
     },
     #' @description Multiply `seconds_interval` by `base`.
     #' @return `NULL` (invisibly). Called for its side effects.
     decelerate = function() {
-      old <- .subset2(private, ".seconds_interval")
-      base <- .subset2(private, ".base")
-      max <- .subset2(private, ".seconds_max")
-      private$.seconds_interval <- min(max, old * base)
+      .seconds_interval <<- min(.seconds_max, .seconds_interval * .base)
       invisible()
     },
     #' @description Reset the throttle object so the next `poll()` returns
     #'   `TRUE`, and reset the wait time interval to its initial value.
     #' @return `NULL` (invisibly).
     reset = function() {
-      private$.seconds_interval <- .subset2(private, ".seconds_start")
-      private$.polled <- -Inf
+      .seconds_interval <<- .seconds_start
+      .polled <<- -Inf
       invisible()
     },
     #' @description Reset the throttle when there is activity and
@@ -218,9 +211,9 @@ crew_class_throttle <- R6::R6Class(
     #' @param activity `TRUE` if there is activity, `FALSE` otherwise.
     update = function(activity) {
       if (activity) {
-        .subset2(self, "reset")()
+        reset()
       } else {
-        .subset2(self, "decelerate")()
+        decelerate()
       }
       invisible()
     }

--- a/R/utils_functional.R
+++ b/R/utils_functional.R
@@ -3,10 +3,6 @@ fltr <- function(x, f, ...) {
   x[index]
 }
 
-map <- function(x, f, ...) {
-  lapply(X = x, FUN = as_function(f), ...)
-}
-
 map_chr <- function(x, f, ...) {
   vapply(X = x, FUN = as_function(f), FUN.VALUE = character(1), ...)
 }
@@ -25,9 +21,4 @@ map_lgl <- function(x, f, ...) {
 
 map_rows <- function(x, f, ...) {
   apply(X = x, MARGIN = 1L, FUN = as_function(f), ...)
-}
-
-walk <- function(x, f, ...) {
-  lapply(X = x, FUN = as_function(f), ...)
-  invisible()
 }

--- a/man/crew_class_controller.Rd
+++ b/man/crew_class_controller.Rd
@@ -11,7 +11,7 @@ See \code{\link[=crew_controller]{crew_controller()}}.
 }
 \examples{
 if (identical(Sys.getenv("CREW_EXAMPLES"), "true")) {
-client <- crew_client()
+client <- crew_client() d
 launcher <- crew_launcher_local()
 controller <- crew_controller(client = client, launcher = launcher)
 controller$start()

--- a/tests/testthat/test-crew_controller_sequential.R
+++ b/tests/testthat/test-crew_controller_sequential.R
@@ -1,8 +1,11 @@
 crew_test("crew_controller_sequential() method and signature compatibility", {
   x <- crew_controller_local()
   y <- crew_controller_sequential()
-  expect_equal(sort(names(x)), sort(names(y)))
-  for (field in names(x)) {
+  expect_equal(
+    setdiff(sort(names(x)), "super"),
+    setdiff(sort(names(y)), "super")
+  )
+  for (field in setdiff(names(x), "super")) {
     function_x <- is.function(x[[field]])
     function_y <- is.function(y[[field]])
     expect_equal(function_x, function_y)

--- a/tests/testthat/test-utils_functional.R
+++ b/tests/testthat/test-utils_functional.R
@@ -2,10 +2,6 @@ crew_test("fltr()", {
   expect_equal(fltr(seq_len(10), ~ .x < 5), seq_len(4))
 })
 
-crew_test("map()", {
-  expect_equal(unname(map(letters, identity)), as.list(letters))
-})
-
 crew_test("map_chr()", {
   expect_equal(unname(map_chr(letters, identity)), letters)
 })
@@ -26,10 +22,4 @@ crew_test("map_lgl()", {
 crew_test("map_rows()", {
   x <- data.frame(x = seq_len(3), y = rep(1, 3), z = rep(2, 3))
   expect_equal(map_rows(x, ~ sum(.x)), seq_len(3) + 3)
-})
-
-crew_test("walk", {
-  envir <- new.env(parent = emptyenv())
-  walk(letters, ~ assign(.x, 1, envir = envir))
-  expect_equal(sort(names(envir)), sort(letters))
 })


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [Contributor Code of Conduct](https://github.com/wlandau/crew/blob/main/CODE_OF_CONDUCT.md).
* [x] I have already submitted a [discussion topic](https://github.com/wlandau/crew/discussions) or [issue](https://github.com/wlandau/crew/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #230

# Summary

This PR sets `portable = FALSE` and reduces explicit references to `self` and `private` in all `R6` classes except launchers. This will likely reduce overhead from managing many tasks, and it definitely simplifies the code base.