### PR TITLE
Make tests compatible with new versions of `nanonext::parse_url()`

### DIFF
--- a/tests/testthat/test-crew_client.R
+++ b/tests/testthat/test-crew_client.R
@@ -114,7 +114,8 @@ crew_test("crew_client() custom profile", {
   on.exit(x$terminate())
   x$start()
   url <- nanonext::parse_url(mirai::nextget("url", .compute = "__abc__"))
-  expect_equal(as.character(url["host"]), "127.0.0.1:57000")
+  expect_equal(as.character(url["hostname"]), "127.0.0.1")
+  expect_equal(as.character(url["port"]), "57000")
 })
 
 crew_test("crew_client() profile conflicts", {

--- a/tests/testthat/test-crew_controller_local.R
+++ b/tests/testthat/test-crew_controller_local.R
@@ -393,7 +393,8 @@ crew_test("custom compute profile", {
   on.exit(x$terminate())
   x$start()
   url <- nanonext::parse_url(mirai::nextget("url", .compute = "__abc__"))
-  expect_equal(as.character(url["host"]), "127.0.0.1:57000")
+  expect_equal(as.character(url["hostname"]), "127.0.0.1")
+  expect_equal(as.character(url["port"]), "57000")
 })
 
 crew_test("deprecate seconds_exit", {


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [Contributor Code of Conduct](https://github.com/wlandau/crew/blob/main/CODE_OF_CONDUCT.md).
* [x] I have already submitted a [discussion topic](https://github.com/wlandau/crew/discussions) or [issue](https://github.com/wlandau/crew/issues) to discuss my idea with the maintainer.

# Related GitHub issues and pull requests

* Ref: #246

# Summary

Fixes #246. 'host' is no longer provided by the underlying NNGv2 library so we're going to remove it at nanonext as well in https://github.com/r-lib/nanonext/pull/207.